### PR TITLE
fix(marshal): invalid marshal for map of byte array.

### DIFF
--- a/unbind.go
+++ b/unbind.go
@@ -123,8 +123,10 @@ func unbindDictionary(v reflect.Value) (Dictionary, error) {
 	return out, nil
 }
 
+var typeOfBytes = reflect.TypeOf([]byte(nil))
+
 func unbindMember(v reflect.Value) (Member, error) {
-	isInnerList := v.Type().Kind() == reflect.Slice
+	isInnerList := v.Type().Kind() == reflect.Slice && v.Type() != typeOfBytes
 	if !isInnerList && v.Type().Kind() == reflect.Struct {
 		for j := 0; j < v.Type().NumField(); j++ {
 			if _, ok := v.Type().Field(j).Tag.Lookup("sfv"); !ok {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -384,3 +384,38 @@ func TestUnmarshal_custom_bare_types(t *testing.T) {
 		})
 	}
 }
+
+func TestUnmarshal_compound_custom_types(t *testing.T) {
+	testCases := []struct {
+		input    string
+		receiver func() interface{}
+		want     interface{}
+	}{
+		{
+			input:    "sig1=:AQIDBA==:, sig2=:AQIDBA==:",
+			receiver: func() interface{} { return &map[string][]byte{} },
+			want: &map[string][]byte{
+				"sig1": {0x01, 0x02, 0x03, 0x04},
+				"sig2": {0x01, 0x02, 0x03, 0x04},
+			},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(fmt.Sprintf("%T", tt.input), func(t *testing.T) {
+			var got interface{}
+			var err error
+
+			got = tt.receiver()
+			err = sfv.Unmarshal(tt.input, got)
+
+			if err != nil {
+				t.Errorf("err: %v", err)
+				return
+			}
+
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("bad unmarshal result: want: %#v, got: %#v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Context

I'm building a library [httpsig](https://github.com/zntrio/httpsig) to provide HTTP Request Signing features based on your parser. I discovered an issue where `map[string][]byte` was marshalled as `sig1=(1 2 3 4)` where it should be `sig1=:<base64>:`.

